### PR TITLE
Load subr-x for using string-trim

### DIFF
--- a/config-parser.el
+++ b/config-parser.el
@@ -6,7 +6,7 @@
 ;; Created: 2016-01-06
 ;; Version: 0.1
 ;; Keywords: convenience, config
-;; Package-Requires: ((cl-lib "0.5"))
+;; Package-Requires: ((emacs "24.4"))
 ;; URL: https://github.com/lujun9972/el-config-parser
 
 ;; This file is NOT part of GNU Emacs.
@@ -35,6 +35,7 @@
 
 ;;; Code:
 (require 'cl-lib)
+(require 'subr-x)
 
 (defun config-parser--parse-section (line)
   "Parse \"[section]\" to '(\"section\")"


### PR DESCRIPTION
And specify minimum Emacs version because subr-x was bundled since Emacs 24.4.
